### PR TITLE
Force refreshing color buffer in case the VI module neglects to.

### DIFF
--- a/module.c
+++ b/module.c
@@ -127,6 +127,9 @@ EXPORT u32 CALL DoRspCycles(u32 cycles)
         message("M_HVQTASK");
         break;
     case M_HVQMTASK:
+        if (GET_RSP_INFO(ShowCFB) == NULL) /* Gfx #1.2 or older specs */
+            break;
+        GET_RSP_INFO(ShowCFB)(); /* forced FB refresh in case gfx plugin skip */
         break;
     }
     run_task();


### PR DESCRIPTION
Maybe the interval should be regulated solely by the graphics plugin, but just in case some of them decline to (such as Jabo's Direct3D8, without "Software rendering" checked), then this should in those cases fix _Pokémon Puzzle League_.